### PR TITLE
One invoke method per model

### DIFF
--- a/src/DotnetFMPlayground.App/Pages/ImagePlayground.razor
+++ b/src/DotnetFMPlayground.App/Pages/ImagePlayground.razor
@@ -4,6 +4,8 @@
 @using Amazon.Bedrock;
 @using Amazon.BedrockRuntime;
 @using DotnetFMPlayground.Core.Models;
+@using DotnetFMPlayground.Core.Models.InferenceParameters.AmazonTitanImageGeneratorG1
+@using DotnetFMPlayground.Core.Models.ModelResponse
 @inject AmazonBedrockRuntimeClient BedrockRuntimeClient
 @inject AmazonBedrockClient BedrockClient
 @inject IJSRuntime JS
@@ -69,18 +71,38 @@
     private async Task OnSubmit(EditContext context)
     {
 
-        Prompt prompt = new();
-        prompt.Add(new PromptItem(PromptItemType.User, userPrompt.Prompt));
+        Prompt prompt =
+        [
+            new PromptItem(PromptItemType.User, userPrompt.Prompt)
+        ];
 
-        var response = await BedrockRuntimeClient.InvokeModelAsync(
-            selectedModel.ModelId,
-            prompt,
-            new()
-            {
-            }
-        );
-
-        imageSrc = $"data:image/jpeg;base64,{(object)response.GetResponse()}";
+        if (selectedModel.ModelId == "amazon.titan-image-generator-v1")
+        {   
+            AmazonTitanImageGeneratorG1Response response = await BedrockRuntimeClient.InvokeTitanImageGeneratorG1ForTextToImageAsync(
+                new TextToImageParams()
+                {
+                    Text = new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString()
+                },
+                new ImageGenerationConfig()
+                {
+                    NumberOfImages = 1,
+                    CfgScale = 8.0f,
+                    Height = 512,
+                    Width = 512,
+                    Quality = ImageGenerationConfig.ImageQuality.Standard,
+                    Seed = 10
+                });
+            imageSrc = $"data:image/jpeg;base64,{(object)response?.Images?.FirstOrDefault()}";
+        }
+        else if (selectedModel.ModelId == ModelIds.STABILITY_AI_STABLE_DIFFUSION_XL_V0)
+        {
+            StableDiffusionXLResponse response = await BedrockRuntimeClient.InvokeStabilityAIStableDiffusionXLv1ForTextToImageAsync(
+                new Core.Models.InferenceParameters.StabilityAIStableDiffusionXL.TextToImageParams
+                {
+                    TextPrompts = new []{ new Core.Models.InferenceParameters.StabilityAIStableDiffusionXL.TextToImageParams.TextPrompt() { Text = new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString()}},
+                });
+            imageSrc = $"data:image/jpeg;base64,{(object)response?.Artifacts?.FirstOrDefault()?.Base64}";
+        }
         StateHasChanged();
         await JS.InvokeVoidAsync("scrollToElement", "ImageId");
     }

--- a/src/DotnetFMPlayground.App/Pages/TextPlayground.razor
+++ b/src/DotnetFMPlayground.App/Pages/TextPlayground.razor
@@ -124,6 +124,18 @@
                 outputText = response?.GetResponse();
                 StateHasChanged();
             }
+            else if (selectedModel.ModelId == ModelIds.COHERE_COMMAND_TEXT_V14)
+            {
+                var response = await BedrockRuntimeClient.InvokeCommandV14(new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString());
+                outputText = response?.GetResponse();
+                StateHasChanged();
+            }
+            else if (selectedModel.ModelId == ModelIds.COHERE_COMMAND_TEXT_LIGHT_V14)
+            {
+                var response = await BedrockRuntimeClient.InvokeCommandLightV14(new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString());
+                outputText = response?.GetResponse();
+                StateHasChanged();
+            }
             else if (!(selectedModel.ResponseStreamingSupported && ModelIds.IsStreamingSupported(selectedModel.ModelId)))
             {
                 outputText = "Thinking...";

--- a/src/DotnetFMPlayground.App/Pages/TextPlayground.razor
+++ b/src/DotnetFMPlayground.App/Pages/TextPlayground.razor
@@ -5,6 +5,8 @@
 @using Amazon.Bedrock.Model;
 @using DotnetFMPlayground.Core.Models;
 @using System.Text.Json;
+@using DotnetFMPlayground.Core.Models.InferenceParameters.AmazonTitanText
+@using TextGenerationConfig = DotnetFMPlayground.Core.Models.InferenceParameters.AI21LabsJurassic2.TextGenerationConfig
 @inject AmazonBedrockRuntimeClient BedrockRuntimeClient
 @inject AmazonBedrockClient BedrockClient
 @inject IJSRuntime JS
@@ -71,33 +73,90 @@
         Prompt prompt = new();
         prompt.Add(new PromptItem(PromptItemType.User, userPrompt.Prompt));
 
-        if (!(selectedModel.ResponseStreamingSupported && ModelIds.IsStreamingSupported(selectedModel.ModelId)))
+        try
         {
-            outputText = "Thinking...";
-            var response = await BedrockRuntimeClient.InvokeModelAsync(
-                selectedModel.ModelId,
-                prompt,
-                new()
-                {
-                    { "max_tokens_to_sample", 300 }
-                }
-            );
-            outputText = response.GetResponse();
-            StateHasChanged();
+
+            if (selectedModel.ModelId == ModelIds.AMAZON_TITAN_TEXT_LITE_G1_V1)
+            {
+                var response = await BedrockRuntimeClient.InvokeTitanTextG1Lite(new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString());
+                outputText = response?.GetResponse();
+                StateHasChanged();
+            }
+            else if (selectedModel.ModelId == ModelIds.AMAZON_TITAN_TEXT_EXPRESS_G1_V1)
+            {
+                var response = await BedrockRuntimeClient.InvokeTitanTextG1Express(new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString());
+                outputText = response?.GetResponse();
+                StateHasChanged();
+            }
+            else if (selectedModel.ModelId == ModelIds.AI21_LABS_JURASSIC_V2_MID_V1)
+            {
+                var response = await BedrockRuntimeClient.InvokeJurassic2MidAsync(new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString());
+                outputText = response?.GetResponse();
+                StateHasChanged();
+            }
+            else if (selectedModel.ModelId == ModelIds.AI21_LABS_JURASSIC_V2_ULTRA_V1)
+            {
+                var response = await BedrockRuntimeClient.InvokeJurassic2UltraAsync(new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString());
+                outputText = response?.GetResponse();
+                StateHasChanged();
+            }
+            else if (selectedModel.ModelId == ModelIds.ANTHROPIC_CLAUDE_V1)
+            {
+                var response = await BedrockRuntimeClient.InvokeClaudeV1Async(new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString());
+                outputText = response?.GetResponse();
+                StateHasChanged();
+            }
+            else if (selectedModel.ModelId == ModelIds.ANTHROPIC_CLAUDE_V2)
+            {
+                var response = await BedrockRuntimeClient.InvokeClaudeV2Async(new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString());
+                outputText = response?.GetResponse();
+                StateHasChanged();
+            }
+            else if (selectedModel.ModelId == ModelIds.ANTHROPIC_CLAUDE_V2_1)
+            {
+                var response = await BedrockRuntimeClient.InvokeClaudeV2_1Async(new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString());
+                outputText = response?.GetResponse();
+                StateHasChanged();
+            }
+            else if (selectedModel.ModelId == ModelIds.ANTHROPIC_CLAUDE_INSTANT_V1)
+            {
+                var response = await BedrockRuntimeClient.InvokeClaudeInstantV1Async(new StringBuilder().AppendJoin(' ', prompt.Select(x => x.Prompt)).ToString());
+                outputText = response?.GetResponse();
+                StateHasChanged();
+            }
+            else if (!(selectedModel.ResponseStreamingSupported && ModelIds.IsStreamingSupported(selectedModel.ModelId)))
+            {
+                outputText = "Thinking...";
+                var response = await BedrockRuntimeClient.InvokeModelAsync(
+                    selectedModel.ModelId,
+                    prompt,
+                    new()
+                    {
+                        { "max_tokens_to_sample", 300 }
+                    }
+                );
+                outputText = response?.GetResponse();
+                StateHasChanged();
+            }
+            else
+            {
+                outputText = "";
+                await BedrockRuntimeClient.InvokeModelWithResponseStreamAsync(
+                    selectedModel.ModelId,
+                    prompt,
+                    new()
+                    {
+                        { "max_tokens_to_sample", 300 }
+                    },
+                    ChunkReceived,
+                    ExceptionReceived
+                );
+            }
         }
-        else
+        catch (Exception e)
         {
-            outputText = "";
-            await BedrockRuntimeClient.InvokeModelWithResponseStreamAsync(
-                selectedModel.ModelId,
-                prompt,
-                new()
-                {
-                    { "max_tokens_to_sample", 300 }
-                },
-                ChunkReceived,
-                ExceptionReceived
-            );
+            outputText = e.Message;
+            StateHasChanged();
         }
     }
 

--- a/src/DotnetFMPlayground.Core/AmazonBedrockRuntimeClientExtension.cs
+++ b/src/DotnetFMPlayground.Core/AmazonBedrockRuntimeClientExtension.cs
@@ -1,10 +1,12 @@
-﻿using Amazon.BedrockRuntime;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Amazon.BedrockRuntime;
 using Amazon.BedrockRuntime.Model;
+using Amazon.Util;
 using DotnetFMPlayground.Core.Builders;
 using DotnetFMPlayground.Core.Models;
-using System.Net;
-using System.Text.Json;
-using System.Text;
 using DotnetFMPlayground.Core.Models.InferenceParameters;
 using DotnetFMPlayground.Core.Models.ModelResponse;
 
@@ -52,5 +54,72 @@ namespace DotnetFMPlayground.Core
 
             response.Body.StartProcessing();
         }
+        
+        /// <summary>
+        /// Invoke Titan Image Generator G1 for text to image generation
+        /// </summary>
+        /// <param name="client">The Amazon Bedrock Runtime client object</param>
+        /// <param name="textToImageParams">The text to image prompt definition</param>
+        /// <param name="imageGenerationConfig">The image configuration definition. If null, default values will be used</param>
+        /// <returns>The Titan Image Generator G1 response</returns>
+        public static async Task<AmazonTitanImageGeneratorG1Response?> InvokeTitanImageGeneratorG1ForTextToImageAsync(
+            this AmazonBedrockRuntimeClient client, Models.InferenceParameters.AmazonTitanImageGeneratorG1.TextToImageParams textToImageParams, Models.InferenceParameters.AmazonTitanImageGeneratorG1.ImageGenerationConfig? imageGenerationConfig = null)
+        {
+            ArgumentNullException.ThrowIfNull(textToImageParams);
+            JsonSerializerOptions jsonSerializerOptions = new(JsonSerializerDefaults.Web)
+            {
+                WriteIndented = true,
+                Converters =
+                {
+                    new JsonStringEnumConverter<Models.InferenceParameters.AmazonTitanImageGeneratorG1.ImageGenerationConfig.ImageQuality>(JsonNamingPolicy.CamelCase)
+                }
+            };
+
+            JsonObject payload = new JsonObject()
+            {
+                ["taskType"] = "TEXT_IMAGE",
+                ["textToImageParams"] = JsonSerializer.SerializeToNode(textToImageParams, jsonSerializerOptions)
+            };
+
+            if (imageGenerationConfig is not null)
+            {
+                payload.Add("imageGenerationConfig", JsonSerializer.SerializeToNode(imageGenerationConfig, jsonSerializerOptions));
+            }
+
+            InvokeModelResponse response = await client.InvokeModelAsync(new InvokeModelRequest()
+            {
+                 ModelId = ModelIds.AMAZON_TITAN_IMAGE_GENERATOR_v1,
+                 ContentType = "application/json",
+                 Accept = "application/json",
+                 Body = AWSSDKUtils.GenerateMemoryStreamFromString(payload.ToJsonString())
+            });
+            
+            return JsonSerializer.Deserialize<AmazonTitanImageGeneratorG1Response>(response.Body, new JsonSerializerOptions());
+        }
+
+        /// <summary>
+        /// Invoke Stability AI Stable Diffusion XL v1 for text to image generation
+        /// </summary>
+        /// <param name="client">The Amazon Bedrock Runtime client object</param>
+        /// <param name="textToImageParams">The text to image prompt definition</param>
+        /// <returns>The Stability AI Stable Diffusion XL response</returns> 
+        public static async Task<StableDiffusionXLResponse?> InvokeStabilityAIStableDiffusionXLv1ForTextToImageAsync(this AmazonBedrockRuntimeClient client, Models.InferenceParameters.StabilityAIStableDiffusionXL.TextToImageParams textToImageParams)
+        {
+            ArgumentNullException.ThrowIfNull(textToImageParams);
+            Validator.ValidateObject(textToImageParams, new ValidationContext(textToImageParams), true);
+            
+            InvokeModelResponse response = await client.InvokeModelAsync(new InvokeModelRequest()
+            {
+                ModelId = ModelIds.STABILITY_AI_STABLE_DIFFUSION_XL_V0,
+                ContentType = "application/json",
+                Accept = "application/json",
+                Body = new MemoryStream(JsonSerializer.SerializeToUtf8Bytes(textToImageParams))
+            });
+            
+            return JsonSerializer.Deserialize<StableDiffusionXLResponse>(response.Body, new JsonSerializerOptions());
+        }
     }
+    
+    
+        
 }

--- a/src/DotnetFMPlayground.Core/Builders/FoundationModelResponseBuilder.cs
+++ b/src/DotnetFMPlayground.Core/Builders/FoundationModelResponseBuilder.cs
@@ -25,9 +25,8 @@ namespace DotnetFMPlayground.Core.Builders
                 case var _ when modelId == ModelIds.STABILITY_AI_STABLE_DIFFUSION_XL_V0:
                     response = await JsonSerializer.DeserializeAsync<StableDiffusionXLResponse>(stream, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
                     break;
-                case var _ when modelId == ModelIds.AMAZON_TITAN_TEXT_LITE_V1:
-                case var _ when modelId == ModelIds.AMAZON_TITAN_TEXT_EXPRESS_V1:
-                case var _ when modelId == ModelIds.AMAZON_TITAN_TEXT_AGILE_V1:
+                case var _ when modelId == ModelIds.AMAZON_TITAN_TEXT_LITE_G1_V1:
+                case var _ when modelId == ModelIds.AMAZON_TITAN_TEXT_EXPRESS_G1_V1:
                     if (streaming)
                     {
                         response = await JsonSerializer.DeserializeAsync<AmazonTitanTextStreamingResponse>(stream, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });

--- a/src/DotnetFMPlayground.Core/Models/InferenceParameters/AI21LabsJurassic2/TextGenerationConfig.cs
+++ b/src/DotnetFMPlayground.Core/Models/InferenceParameters/AI21LabsJurassic2/TextGenerationConfig.cs
@@ -1,0 +1,88 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DotnetFMPlayground.Core.Models.InferenceParameters.AI21LabsJurassic2;
+
+public class TextGenerationConfig
+{
+    [Range(0, 1)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("temperature")]
+    public float Temperature { get; set; }
+
+    [Range(0, 1)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("topP")]
+    public float TopP { get; set; }
+
+    [Range(0, 8191)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("maxTokens")]
+    public int MaxTokens { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("stopSequences")]
+    public IEnumerable<string>? StopSequences { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("countPenalty")]
+    public CPenalty? CountPenalty { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("presencePenalty")]
+    public PPenalty? PresencePenalty { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("frequencyPenalty")]
+    public FPenalty? FrequencyPenalty { get; set; }
+
+    public class Penalty
+    {
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("applyToWhiteSpaces")]
+        public bool ApplyToWhitespaces { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("applyToPunctuations")]
+        public bool ApplyToPunctuations { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("applyToNumbers")]
+        public bool ApplyToNumbers { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("applyToStopWords")]
+        public bool ApplyToStopWords { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("applyToEmojis")]
+        public bool ApplyToEmojis { get; set; }
+    }
+
+    public class CPenalty : Penalty
+    {
+        [Range(0, 1)]
+        [Required]
+        [JsonPropertyName("scale")]
+        [JsonRequired]
+        public float Scale { get; set; }
+    }
+
+    public class PPenalty : Penalty
+    {
+        [Range(0, 5)]
+        [Required]
+        [JsonPropertyName("scale")]
+        [JsonRequired]
+        public float Scale { get; set; }
+    }
+
+    public class FPenalty : Penalty
+    {
+        [Range(0, 500)]
+        [Required]
+        [JsonPropertyName("scale")]
+        [JsonRequired]
+        public float Scale { get; set; }
+    }
+}

--- a/src/DotnetFMPlayground.Core/Models/InferenceParameters/AmazonTitanImageGeneratorG1/ImageGenerationConfig.cs
+++ b/src/DotnetFMPlayground.Core/Models/InferenceParameters/AmazonTitanImageGeneratorG1/ImageGenerationConfig.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DotnetFMPlayground.Core.Models.InferenceParameters.AmazonTitanImageGeneratorG1
+{
+    public class ImageGenerationConfig
+    {
+        [Range(1, 5)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyOrder(1)]
+        public int NumberOfImages { get; set; }
+
+        [JsonPropertyOrder(2)] public ImageQuality Quality { get; set; }
+
+        [Range(1, 1024)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyOrder(4)]
+        public int Height { get; set; }
+
+        [Range(1, 1024)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyOrder(5)]
+        public int Width { get; set; }
+
+        [Range(1.0, 10.0)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyOrder(3)]
+        public float CfgScale { get; set; }
+
+        [Range(0, 214783647)]
+        [JsonPropertyOrder(6)]
+        public int Seed { get; set; }
+
+        public enum ImageQuality
+        {
+            Standard,
+            Premium
+        }
+    }
+}

--- a/src/DotnetFMPlayground.Core/Models/InferenceParameters/AmazonTitanImageGeneratorG1/TaskType.cs
+++ b/src/DotnetFMPlayground.Core/Models/InferenceParameters/AmazonTitanImageGeneratorG1/TaskType.cs
@@ -1,0 +1,9 @@
+namespace DotnetFMPlayground.Core.Models.InferenceParameters.AmazonTitanImageGeneratorG1;
+
+public enum TaskType
+{
+    TextImage,
+    InPainting,
+    OutPainting,
+    ImageVariation
+}

--- a/src/DotnetFMPlayground.Core/Models/InferenceParameters/AmazonTitanImageGeneratorG1/TextToImageParams.cs
+++ b/src/DotnetFMPlayground.Core/Models/InferenceParameters/AmazonTitanImageGeneratorG1/TextToImageParams.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DotnetFMPlayground.Core.Models.InferenceParameters.AmazonTitanImageGeneratorG1;
+
+public class TextToImageParams
+{
+    public required string Text { get; init; }
+    
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? NegativeText { get; set; }
+    
+}

--- a/src/DotnetFMPlayground.Core/Models/InferenceParameters/AmazonTitanText/TextGenerationConfig.cs
+++ b/src/DotnetFMPlayground.Core/Models/InferenceParameters/AmazonTitanText/TextGenerationConfig.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DotnetFMPlayground.Core.Models.InferenceParameters.AmazonTitanText;
+
+public class TextGenerationConfig
+{
+    [Range(0, 1)]
+    [DefaultValue(0)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyOrder(1)]
+    [JsonPropertyName("temperature")]
+    public float Temperature { get; set; }
+    
+    [Range(0, 1)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [DefaultValue(1)]
+    [JsonPropertyOrder(2)]
+    [JsonPropertyName("topP")]
+    public float TopP { get; set; }
+    
+    [Range(0, 8000)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [DefaultValue(512)]
+    [JsonPropertyOrder(3)]
+    [JsonPropertyName("maxTokenCount")]
+    public int MaxTokenCount { get; set; }
+    
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyOrder(5)]
+    [JsonPropertyName("stopSequences")]
+    public IEnumerable<string>? StopSequences { get; set; }
+}
+

--- a/src/DotnetFMPlayground.Core/Models/InferenceParameters/AnthropicClaude/TextGenerationConfig.cs
+++ b/src/DotnetFMPlayground.Core/Models/InferenceParameters/AnthropicClaude/TextGenerationConfig.cs
@@ -6,28 +6,22 @@ namespace DotnetFMPlayground.Core.Models.InferenceParameters.AnthropicClaude;
 
 public class TextGenerationConfig
 {
-
     [Range(0f, 1f)]
-    [DefaultValue(0.5f)]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("temperature")]
-    public float Temperature { get; init; } = 0.5f;
+    public float? Temperature { get; init; }
 
     [Range(0f, 1f)]
-    [DefaultValue(1f)]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("top_p")]
-    public float TopP { get; init; } = 1f;
+    public float? TopP { get; init; }
 
     [Range(0, 500)]
-    [DefaultValue(250)]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("top_k")] 
-    public int TopK { get; init; } = 250;
+    public int? TopK { get; init; }
 
     [Range(0, 4096)]
-    [DefaultValue(200)]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("max_tokens_to_sample")]
     private int MaxTokensToSample { get; init; } = 200;
 

--- a/src/DotnetFMPlayground.Core/Models/InferenceParameters/AnthropicClaude/TextGenerationConfig.cs
+++ b/src/DotnetFMPlayground.Core/Models/InferenceParameters/AnthropicClaude/TextGenerationConfig.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DotnetFMPlayground.Core.Models.InferenceParameters.AnthropicClaude;
+
+public class TextGenerationConfig
+{
+
+    [Range(0f, 1f)]
+    [DefaultValue(0.5f)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("temperature")]
+    public float Temperature { get; init; } = 0.5f;
+
+    [Range(0f, 1f)]
+    [DefaultValue(1f)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("top_p")]
+    public float TopP { get; init; } = 1f;
+
+    [Range(0, 500)]
+    [DefaultValue(250)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("top_k")] 
+    public int TopK { get; init; } = 250;
+
+    [Range(0, 4096)]
+    [DefaultValue(200)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("max_tokens_to_sample")]
+    private int MaxTokensToSample { get; init; } = 200;
+
+    [JsonPropertyName("stop_sequences")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    IEnumerable<string>? StopSequences { get; init; }
+}

--- a/src/DotnetFMPlayground.Core/Models/InferenceParameters/Cohere/TextGenerationConfig.cs
+++ b/src/DotnetFMPlayground.Core/Models/InferenceParameters/Cohere/TextGenerationConfig.cs
@@ -1,0 +1,65 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DotnetFMPlayground.Core.Models.InferenceParameters.Cohere;
+
+public class TextGenerationConfig
+{
+    [Range(0f, 5f)]
+    [JsonPropertyName("temperature")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public float? Temperature { get; init; }
+    
+    [Range(0f, 1f)]
+    [JsonPropertyName("p")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public float? P { get; init; }
+    
+    [Range(0f, 500f)]
+    [JsonPropertyName("k")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public float? K { get; init; }
+    
+    [Range(1, 4096)]
+    [JsonPropertyName("max_tokens")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxTokens { get; init; }
+    
+    [JsonPropertyName("stop_sequences")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IEnumerable<string>? StopSequences { get; init; }
+    
+    [JsonPropertyName("return_likelihoods")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ReturnLikelihoodsEnum? ReturnLikelihoods { get; init; }
+    
+    [JsonPropertyName("stream")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Stream { get; init; }
+    
+    [Range(1, 5)]
+    [JsonPropertyName("num_generations")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? NumGenerations { get; init; }
+    
+    [JsonPropertyName("truncate")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public TruncateEnum? Truncate { get; init; }
+    
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum ReturnLikelihoodsEnum
+    {
+        GENERATION,
+        ALL,
+        NONE
+    }
+    
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum TruncateEnum
+    {
+        NONE,
+        START,
+        END
+    }
+}

--- a/src/DotnetFMPlayground.Core/Models/InferenceParameters/StabilityAIStableDiffusionXL/TextToImageParams.cs
+++ b/src/DotnetFMPlayground.Core/Models/InferenceParameters/StabilityAIStableDiffusionXL/TextToImageParams.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DotnetFMPlayground.Core.Models.InferenceParameters.StabilityAIStableDiffusionXL;
+
+public class TextToImageParams
+{
+    [JsonPropertyName("text_prompts")]
+    public required IEnumerable<TextPrompt> TextPrompts { get; init;}
+    
+    [JsonPropertyName("height")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [AllowedValues(null, 1024, 896, 832, 768, 640, 1536, 1344, 1216, 1152)]
+    public int? Height { get; set; }
+    
+    [JsonPropertyName("width")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [AllowedValues(null, 1024, 896, 832, 768, 640, 1536, 1344, 1216, 1152)]
+    public int? Width { get; set; }
+    
+    [JsonPropertyName("sampler")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [AllowedValues(null, "DDIM", "DDPM", "K_DPMPP_2M", "K_DPMPP_2S_ANCESTRAL", "K_DPM_2", "K_DPM_2_ANCESTRAL", "K_EULER", "K_EULER_ANCESTRAL", "K_HEUN", "K_LMS")]
+    public string? Sampler { get; set; }
+    
+    [JsonPropertyName("seed")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Range(0, 4294967295)]
+    public int? Seed { get; set; }
+    
+    [JsonPropertyName("steps")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Range(10, 50)]
+    public int? Steps { get; set; }
+    
+    [JsonPropertyName("style_preset")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [AllowedValues(null, "3d-model", "analog-film", "anime", "cinematic", "comic-book", "digital-art", "enhance", "fantasy-art", "isometric", "line-art", "low-poly", "modelin-compound", "neon-punk", "origami", "photographic", "pixel-art", "tile-texture")]
+    public string? StylePreset { get; set; }
+    
+    public struct TextPrompt
+    {
+        [JsonPropertyName("text")]
+        public required string Text { get; init; }
+        
+        [JsonPropertyName("weight")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public float? Weight { get; set; }
+    }
+}

--- a/src/DotnetFMPlayground.Core/Models/ModelIds.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelIds.cs
@@ -18,7 +18,7 @@ namespace DotnetFMPlayground.Core.Models
             "amazon.titan-text-lite-v1",
             "amazon.titan-text-express-v1",
             "amazon.titan-text-agile-v1",
-            "amazon.titan-embed-text-v1",
+            "amazon.titan-image-generator-v1",
             "cohere.command-text-v14",
             "ai21.j2-mid-v1",
             "ai21.j2-ultra-v1"
@@ -90,14 +90,6 @@ namespace DotnetFMPlayground.Core.Models
             }
         }
 
-        public static string AMAZON_TITAN_EMBED_TEXT_V1
-        {
-            get
-            {
-                return modelIds[7];
-            }
-        }
-
         public static string COHERE_COMMAND_TEXT_V14
         {
             get
@@ -119,6 +111,14 @@ namespace DotnetFMPlayground.Core.Models
             get
             {
                 return modelIds[10];
+            }
+        }
+        
+        public static string AMAZON_TITAN_IMAGE_GENERATOR_v1
+        {
+            get
+            {
+                return modelIds[7];
             }
         }
 

--- a/src/DotnetFMPlayground.Core/Models/ModelIds.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelIds.cs
@@ -9,127 +9,62 @@ namespace DotnetFMPlayground.Core.Models
 {
     public static class ModelIds
     {
-        private static readonly List<string> modelIds = new()
-        {
+        private static readonly IList<string> Ids =
+        [
             "anthropic.claude-instant-v1",
             "anthropic.claude-v1",
             "anthropic.claude-v2",
             "stability.stable-diffusion-xl-v0",
             "amazon.titan-text-lite-v1",
             "amazon.titan-text-express-v1",
-            "amazon.titan-text-agile-v1",
             "amazon.titan-image-generator-v1",
             "cohere.command-text-v14",
             "ai21.j2-mid-v1",
-            "ai21.j2-ultra-v1"
-        };
+            "ai21.j2-ultra-v1",
+            "anthropic.claude-v2:1"
+        ];
 
-        private static readonly List<string> streamingSupported = new()
-        {
+        private static readonly IList<string> StreamingSupported =
+        [
             "anthropic.claude-instant-v1",
             "anthropic.claude-v1",
             "anthropic.claude-v2",
             "amazon.titan-text-lite-v1",
             "amazon.titan-text-express-v1",
-            "amazon.titan-text-agile-v1"
-        };
+            "anthropic.claude-v2:1"
+        ];
 
-        public static string ANTHROPIC_CLAUDE_INSTANT_V1
-        {
-            get
-            {
-                return modelIds[0];
-            }
-        } 
+        public static string ANTHROPIC_CLAUDE_INSTANT_V1 => Ids[0];
+
+        public static string ANTHROPIC_CLAUDE_V1 => Ids[1];
+
+        public static string ANTHROPIC_CLAUDE_V2 => Ids[2];
         
-        public static string ANTHROPIC_CLAUDE_V1
-        {
-            get
-            {
-                return modelIds[1];
-            }
-        } 
-        
-        public static string ANTHROPIC_CLAUDE_V2
-        {
-            get
-            {
-                return modelIds[2];
-            }
-        }
+        public static string ANTHROPIC_CLAUDE_V2_1 => Ids[10];
 
-        public static string STABILITY_AI_STABLE_DIFFUSION_XL_V0
-        {
-            get
-            {
-                return modelIds[3];
-            }
-        }
+        public static string STABILITY_AI_STABLE_DIFFUSION_XL_V0 => Ids[3];
 
-        public static string AMAZON_TITAN_TEXT_LITE_V1
-        {
-            get
-            {
-                return modelIds[4];
-            }
-        }
+        public static string AMAZON_TITAN_TEXT_LITE_G1_V1 => Ids[4];
 
-        public static string AMAZON_TITAN_TEXT_EXPRESS_V1
-        {
-            get
-            {
-                return modelIds[5];
-            }
-        }
+        public static string AMAZON_TITAN_TEXT_EXPRESS_G1_V1 => Ids[5];
 
-        public static string AMAZON_TITAN_TEXT_AGILE_V1
-        {
-            get
-            {
-                return modelIds[6];
-            }
-        }
+        public static string AMAZON_TITAN_IMAGE_GENERATOR_G1_V1 => Ids[6];
 
-        public static string COHERE_COMMAND_TEXT_V14
-        {
-            get
-            {
-                return modelIds[8];
-            }
-        }
+        public static string COHERE_COMMAND_TEXT_V14 => Ids[7];
 
-        public static string AI21_LABS_JURASSIC_V2_MID_V1
-        {
-            get
-            {
-                return modelIds[9];
-            }
-        }
+        public static string AI21_LABS_JURASSIC_V2_MID_V1 => Ids[8];
 
-        public static string AI21_LABS_JURASSIC_V2_ULTRA_V1
-        {
-            get
-            {
-                return modelIds[10];
-            }
-        }
-        
-        public static string AMAZON_TITAN_IMAGE_GENERATOR_v1
-        {
-            get
-            {
-                return modelIds[7];
-            }
-        }
+        public static string AI21_LABS_JURASSIC_V2_ULTRA_V1 => Ids[9];
+
 
         public static bool IsSupported(string modelId)
         {
-            return modelIds.Contains(modelId);
+            return Ids.Contains(modelId);
         }
 
         public static bool IsStreamingSupported(string modelId)
         {
-            return streamingSupported.Contains(modelId);
+            return StreamingSupported.Contains(modelId);
         }
 
 

--- a/src/DotnetFMPlayground.Core/Models/ModelIds.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelIds.cs
@@ -21,7 +21,8 @@ namespace DotnetFMPlayground.Core.Models
             "cohere.command-text-v14",
             "ai21.j2-mid-v1",
             "ai21.j2-ultra-v1",
-            "anthropic.claude-v2:1"
+            "anthropic.claude-v2:1",
+            "cohere.command-light-text-v14"
         ];
 
         private static readonly IList<string> StreamingSupported =
@@ -51,6 +52,8 @@ namespace DotnetFMPlayground.Core.Models
         public static string AMAZON_TITAN_IMAGE_GENERATOR_G1_V1 => Ids[6];
 
         public static string COHERE_COMMAND_TEXT_V14 => Ids[7];
+        
+        public static string COHERE_COMMAND_TEXT_LIGHT_V14 => Ids[11];
 
         public static string AI21_LABS_JURASSIC_V2_MID_V1 => Ids[8];
 

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/AI21LabsJurassic2Response.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/AI21LabsJurassic2Response.cs
@@ -1,72 +1,61 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
 namespace DotnetFMPlayground.Core.Models.ModelResponse
 {
     public class AI21LabsJurassic2Response : IFoundationModelResponse
     {
-        //{"id":1234,"prompt":{"text":"Hello Jurassic","tokens":[{"generatedToken":{"token":"▁Hello","logprob":-8.374051094055176,"raw_logprob":-8.374051094055176},"topTokens":null,"textRange":{"start":0,"end":5}},{ "generatedToken":{ "token":"▁","logprob":-5.375925064086914,"raw_logprob":-5.375925064086914},"topTokens":null,"textRange":{ "start":5,"end":6} },{ "generatedToken":{ "token":"Jurassic","logprob":-12.566287994384766,"raw_logprob":-12.566287994384766},"topTokens":null,"textRange":{ "start":6,"end":14} }]},"completions":[{"data":{"text":"\nHello, welcome to Jurassic! What would you like to know or discuss about jurassi","tokens":[{"generatedToken":{"token":"<|newline|>","logprob":-0.2771032452583313,"raw_logprob":-0.2771032452583313},"topTokens":null,"textRange":{ "start":0,"end":1}},{ "generatedToken":{ "token":"▁Hello","logprob":-1.1910626888275146,"raw_logprob":-1.1910626888275146},"topTokens":null,"textRange":{ "start":1,"end":6} },{ "generatedToken":{ "token":",","logprob":-1.5938622951507568,"raw_logprob":-1.5938622951507568},"topTokens":null,"textRange":{ "start":6,"end":7} },{ "generatedToken":{ "token":"▁welcome▁to","logprob":-5.078219413757324,"raw_logprob":-5.078219413757324},"topTokens":null,"textRange":{ "start":7,"end":18} },{ "generatedToken":{ "token":"▁","logprob":-1.185720443725586,"raw_logprob":-1.185720443725586},"topTokens":null,"textRange":{ "start":18,"end":19} },{ "generatedToken":{ "token":"Jurassic","logprob":-0.011890722438693047,"raw_logprob":-0.011890722438693047},"topTokens":null,"textRange":{ "start":19,"end":27} },{ "generatedToken":{ "token":"!","logprob":-0.3744388818740845,"raw_logprob":-0.3744388818740845},"topTokens":null,"textRange":{ "start":27,"end":28} },{ "generatedToken":{ "token":"▁What","logprob":-5.624349594116211,"raw_logprob":-5.624349594116211},"topTokens":null,"textRange":{ "start":28,"end":33} },{ "generatedToken":{ "token":"▁would▁you▁like▁to","logprob":-0.4887925386428833,"raw_logprob":-0.4887925386428833},"topTokens":null,"textRange":{ "start":33,"end":51} },{ "generatedToken":{ "token":"▁know","logprob":-0.03536876663565636,"raw_logprob":-0.03536876663565636},"topTokens":null,"textRange":{ "start":51,"end":56} },{ "generatedToken":{ "token":"▁or","logprob":-0.018549775704741478,"raw_logprob":-0.018549775704741478},"topTokens":null,"textRange":{ "start":56,"end":59} },{ "generatedToken":{ "token":"▁discuss","logprob":-0.21317188441753387,"raw_logprob":-0.21317188441753387},"topTokens":null,"textRange":{ "start":59,"end":67} },{ "generatedToken":{ "token":"▁about","logprob":-1.4178533554077148,"raw_logprob":-1.4178533554077148},"topTokens":null,"textRange":{ "start":67,"end":73} },{ "generatedToken":{ "token":"▁","logprob":-2.306314706802368,"raw_logprob":-2.306314706802368},"topTokens":null,"textRange":{ "start":73,"end":74} },{ "generatedToken":{ "token":"jur","logprob":-4.701274871826172,"raw_logprob":-4.701274871826172},"topTokens":null,"textRange":{ "start":74,"end":77} },{ "generatedToken":{ "token":"assi","logprob":-0.0061679016798734665,"raw_logprob":-0.0061679016798734665},"topTokens":null,"textRange":{ "start":77,"end":81} }]},"finishReason":{ "reason":"length","length":16}}]}
-        public uint? Id { get; init; }
+        [JsonPropertyName("id")] public int? Id { get; init; }
 
-        public Jurassic2Prompt? Prompt { get; init; }
+        [JsonPropertyName("prompt")] public J2Text? Prompt { get; init; }
 
-        public class Jurassic2TokenDetails
+        [JsonPropertyName("completions")]
+        public IEnumerable<J2Completion>? Completions { get; init; }
+
+        public class J2Text
         {
-            public string? Token { get; init; }
+            [JsonPropertyName("text")] public string? Text { get; init; }
 
-            public decimal? LogProb { get; init; }
-
-            public decimal? Raw_LogProb { get; init; }
+            [JsonPropertyName("tokens")] public IEnumerable<J2Token>? Tokens { get; init; }
         }
 
-        public class Jurassic2TokenRange
+        public class J2Token
         {
-            public int? Start { get; init; }
+            [JsonPropertyName("generatedToken")] public J2GeneratedToken? GeneratedToken { get; init; }
 
-            public int? End { get; init; }
+            [JsonPropertyName("topTokens")] public string? TopTokens { get; init; }
+
+            [JsonPropertyName("textRange")] public J2TextRange? TextRange { get; init; }
         }
 
-        public class Jurassic2Token
+        public class J2GeneratedToken
         {
-            public Jurassic2TokenDetails? GeneratedToken { get; init; }
+            [JsonPropertyName("token")] public string? Token { get; init; }
 
-            public Jurassic2TokenRange? TextRange { get; init; }
+            [JsonPropertyName("logprob")] public double? LogProb { get; init; }
 
+            [JsonPropertyName("raw_logprob")] public double? RawLogProb { get; init; }
         }
 
-        public class Jurassic2Prompt
+        public class J2TextRange
         {
-            public string? Text { get; init; }
+            [JsonPropertyName("start")] public int? Start { get; init; }
 
-            public IEnumerable<Jurassic2Token>? Tokens { get; init; }
+            [JsonPropertyName("end")] public int? End { get; init; }
         }
 
-        public class Jurassic2CompletionData
+        public class J2Completion
         {
-            public string? Text { get; init; }
+            [JsonPropertyName("data")] public J2Text? Data { get; init; }
 
-            public IEnumerable<Jurassic2Token>? Tokens { get; init; }
+            [JsonPropertyName("finishReason")] public J2FinishReason? FinishReason { get; init; }
         }
 
-        public class Jurassic2FinishReason
+        public class J2FinishReason
         {
-            public string? Reason { get; init; }
+            [JsonPropertyName("reason")] public string? Reason { get; init; }
 
-            public uint? Length { get; init; }
-
+            [JsonPropertyName("length")] public int? Length { get; init; }
         }
-
-        public class Jurassic2Completion
-        {
-            public Jurassic2CompletionData? Data { get; init; }
-
-            public Jurassic2FinishReason? FinishReason { get; init; }
-        }
-
-        public IEnumerable<Jurassic2Completion>? Completions { get; init; }
 
 
         public string? GetResponse()

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/AmazonTitanEmbeddingsResponse.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/AmazonTitanEmbeddingsResponse.cs
@@ -1,0 +1,6 @@
+namespace DotnetFMPlayground.Core.Models.ModelResponse;
+
+public class AmazonTitanEmbeddingsResponse
+{
+    
+}

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/AmazonTitanImageGeneratorG1Response.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/AmazonTitanImageGeneratorG1Response.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+using Amazon.Auth.AccessControlPolicy;
+
+namespace DotnetFMPlayground.Core.Models.ModelResponse;
+
+public class AmazonTitanImageGeneratorG1Response
+{
+    [JsonPropertyName("images")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IEnumerable<string>? Images { get; set; }
+    
+    [JsonPropertyName("error")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Error { get; set; }
+}

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/AmazonTitanMultimodalEmbeddingsResponse.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/AmazonTitanMultimodalEmbeddingsResponse.cs
@@ -1,0 +1,6 @@
+namespace DotnetFMPlayground.Core.Models.ModelResponse;
+
+public class AmazonTitanMultimodalEmbeddingsResponse
+{
+    
+}

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/AmazonTitanTextResponse.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/AmazonTitanTextResponse.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace DotnetFMPlayground.Core.Models.ModelResponse
@@ -10,24 +11,30 @@ namespace DotnetFMPlayground.Core.Models.ModelResponse
     {
         public class AmazonTitanTextOutput
         {
+            [JsonPropertyName("tokenCount")]
             public int TokenCount { get; set; }
 
+            [JsonPropertyName("outputText")]
             public string? OutputText { get; set; }
 
+            [JsonPropertyName("completionReason")]
             public string? CompletionReason { get; set; }
         }
+        
+        [JsonPropertyName("inputTextTokenCount")]
         public int InputTextTokenCount { get; set; }
 
-        public IEnumerable<AmazonTitanTextOutput>? results { get; set; }
+        [JsonPropertyName("results")]
+        public IEnumerable<AmazonTitanTextOutput>? Results { get; set; }
 
         public string? GetResponse()
         {
-            return results?.FirstOrDefault()?.OutputText;
+            return Results?.FirstOrDefault()?.OutputText;
         }
 
         public string? GetStopReason()
         {
-            return results?.FirstOrDefault()?.CompletionReason;
+            return Results?.FirstOrDefault()?.CompletionReason;
         }
     }
 }

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/AnthropicClaudeResponse.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/AnthropicClaudeResponse.cs
@@ -1,16 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
 namespace DotnetFMPlayground.Core.Models.ModelResponse
 {
     public class AnthropicClaudeResponse : IFoundationModelResponse
     {
-        public string? Completion { get; set; }
+        [JsonPropertyName("completion")] public string? Completion { get; init; }
 
-        public string? Stop_Reason { get; set; }
+        [JsonPropertyName("stop_reason")] public string? StopReason { get; init; }
+        
+        [JsonPropertyName("stop")] public string? Stop { get; init; }
 
         public string? GetResponse()
         {
@@ -19,7 +17,7 @@ namespace DotnetFMPlayground.Core.Models.ModelResponse
 
         public string? GetStopReason()
         {
-            return Stop_Reason;
+            return StopReason;
         }
     }
 }

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/CohereCommandResponse.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/CohereCommandResponse.cs
@@ -2,37 +2,56 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace DotnetFMPlayground.Core.Models.ModelResponse
 {
     public class CohereCommandResponse : IFoundationModelResponse
-    {
-        public class CohereCommandGeneration
+    { 
+        [JsonPropertyName("generations")] public IEnumerable<Generation>? Generations { get; set; }
+
+        [JsonPropertyName("id")] public string? Id { get; init; }
+
+        [JsonPropertyName("prompt")] public string? Prompt { get; init; }
+        
+        public class Generation
         {
-            public int TokenCount { get; init; }
-
-            public string? Text { get; init; }
-
-            public string? Id { get; init; }
-
-            public string? Finish_Reason { get; init; }
+            [JsonPropertyName("finish_reason")] public FinishReason? FinishReason { get; init; }
+            
+            [JsonPropertyName("id")] public string? Id { get; init; }
+            
+            [JsonPropertyName("text")] public string? Text { get; init; }
+            
+            [JsonPropertyName("prompt")] public string? Prompt { get; init; }
+            
+            [JsonPropertyName("likelihood")] public float? Likelihood { get; init; }
+            
+            [JsonPropertyName("token_likelihoods")] public IEnumerable<JsonObject>? TokenLikelihoods { get; init; }
+            
+            [JsonPropertyName("is_finished")] public bool? IsFinished { get; init; }
+            
+            [JsonPropertyName("index")] public int? Index { get; init; }
         }
 
-        public IEnumerable<CohereCommandGeneration>? generations { get; set; }
-
-        public string? Id { get; init; }
-
-        public string? Prompt { get; init; }
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public enum FinishReason
+        {
+            COMPLETE,
+            MAX_TOKENS,
+            ERROR,
+            ERROR_TOXIC
+        }
 
         public string? GetResponse()
         {
-            return generations?.FirstOrDefault()?.Text;
+            return Generations?.FirstOrDefault()?.Text;
         }
 
         public string? GetStopReason()
         {
-            return generations?.FirstOrDefault()?.Finish_Reason;
+            return Generations?.FirstOrDefault()?.FinishReason.ToString();
         }
     }
 }

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/CohereEmbedEnglishResponse.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/CohereEmbedEnglishResponse.cs
@@ -1,0 +1,6 @@
+namespace DotnetFMPlayground.Core.Models.ModelResponse;
+
+public class CohereEmbedEnglishResponse
+{
+    
+}

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/CohereEmbedMultilingualResponse.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/CohereEmbedMultilingualResponse.cs
@@ -1,0 +1,6 @@
+namespace DotnetFMPlayground.Core.Models.ModelResponse;
+
+public class CohereEmbedMultilingualResponse
+{
+    
+}

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/MetaLlama2ChatResponse.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/MetaLlama2ChatResponse.cs
@@ -1,0 +1,6 @@
+namespace DotnetFMPlayground.Core.Models.ModelResponse;
+
+public class MetaLlama2ChatResponse
+{
+    
+}

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/MetaLlama2Response.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/MetaLlama2Response.cs
@@ -1,0 +1,6 @@
+namespace DotnetFMPlayground.Core.Models.ModelResponse;
+
+public class MetaLlama2Response
+{
+    
+}

--- a/src/DotnetFMPlayground.Core/Models/ModelResponse/StableDiffusionXLResponse.cs
+++ b/src/DotnetFMPlayground.Core/Models/ModelResponse/StableDiffusionXLResponse.cs
@@ -2,22 +2,31 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace DotnetFMPlayground.Core.Models.ModelResponse
 {
     public class StableDiffusionXLResponse : IFoundationModelResponse
     {
-        public class StableDiffusionXLOutput
+        public class StableDiffusionXLGeneratedImage
         {
+            [JsonPropertyName("base64")]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]    
             public string? Base64 { get; set; }
 
+            [JsonPropertyName("finishReason")]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public string? FinishReason { get; set; }
 
+            [JsonPropertyName("seed")]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public long? Seed { get; set; }
         }
 
-        public IEnumerable<StableDiffusionXLOutput>? Artifacts { get; set; }
+        [JsonPropertyName("artifacts")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public IEnumerable<StableDiffusionXLGeneratedImage>? Artifacts { get; set; }
 
         public string? GetResponse()
         {


### PR DESCRIPTION
The code changes move the playground to dedicated invoke model methods per model.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
